### PR TITLE
Enable 'Configure' Link from Modules page

### DIFF
--- a/ps_qualityassurance.php
+++ b/ps_qualityassurance.php
@@ -97,4 +97,10 @@ class Ps_Qualityassurance extends Module
             }
         }
     }
+
+    public function getContent()
+    {
+        $moduleAdminLink = Context::getContext()->link->getAdminLink('AdminQualityAssurance', true);
+        Tools::redirectAdmin($moduleAdminLink);
+    }
 }


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This enables a "Configure" button that redirect BO user to Module page, when the user browses the PS QA module in Modules BO page (see screenshot below)
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Install module, see new "Configure" item in menu option inside BO page

# Screenshot

![Capture d’écran 2020-08-21 à 15 45 09](https://user-images.githubusercontent.com/3830050/90897472-750bee00-e3c5-11ea-9ed3-29a1ffbf0cb6.png)
