### PR TITLE
Enable recording hook calls

### DIFF
--- a/_dev/back/App.vue
+++ b/_dev/back/App.vue
@@ -37,6 +37,15 @@
           Register hook
         </router-link>
       </li>
+      <li class="nav-item">
+        <router-link
+          to="/logs"
+          class="nav-link"
+          active-class="active"
+        >
+          Hook call logs
+        </router-link>
+      </li>
     </ul>
 
     <router-view />

--- a/_dev/back/lib/api.js
+++ b/_dev/back/lib/api.js
@@ -74,7 +74,7 @@ const api = {
   },
   getHookCallLogs() {
     return makeGetRequest(urls.logs);
-  }
+  },
 };
 
 export default api;

--- a/_dev/back/lib/api.js
+++ b/_dev/back/lib/api.js
@@ -72,6 +72,9 @@ const api = {
   getRegisteredHooks() {
     return makeGetRequest(urls.registeredHooks);
   },
+  getHookCallLogs() {
+    return makeGetRequest(urls.logs);
+  }
 };
 
 export default api;

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -1,0 +1,84 @@
+<!--**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *-->
+<template>
+  <div class="panel">
+    <table class="table table-striped" v-for="(logs, requestIdentifier) in logsGroupedByRequest" :key="requestIdentifier">
+      <thead>
+      <tr>
+        <th>#</th>
+        <th>Hook</th>
+        <th>Parameters</th>
+        <th>Output</th>
+        <th>Time</th>
+        <th>Status</th>
+      </tr>
+      </thead>
+      <tbody>
+        <tr v-for="log in logs" :key="log.id" v-bind:class="{ 'table-danger': (log.error === '1') }">
+          <th scope="row">{{ log.id }}</th>
+          <td>{{ log.hook_name }}</td>
+          <td>{{ log.hook_parameters }}</td>
+          <td>{{ log.output }}</td>
+          <td>{{ log.called_at }}</td>
+          <td>
+            <i
+              class="material-icons"
+            >
+              <template v-if="log.error === '0'">
+                check
+              </template>
+              <template v-else>
+                clear
+              </template>
+            </i>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+  import api from '@/lib/api';
+
+  export default {
+    name: 'Logs',
+    data() {
+      return {
+        logsGroupedByRequest: [],
+      };
+    },
+    mounted() {
+      this.refreshLogs();
+    },
+    methods: {
+      refreshLogs() {
+        api.getHookCallLogs().then((res) => {
+          this.logsGroupedByRequest = res.data;
+        });
+      },
+    },
+  };
+</script>

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -40,9 +40,11 @@
         </tr>
       </thead>
       <tbody>
-        <tr v-for="log in logs"
-        :key="log.id"
-        :class="{ 'table-danger': (log.error === '1') }">
+        <tr 
+          v-for="log in logs"
+          :key="log.id"
+          :class="{ 'table-danger': (log.error === '1') }"
+        >
           <th scope="row">{{ log.id }}</th>
           <td>{{ log.hook_name }}</td>
           <td>{{ log.hook_parameters }}</td>

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -24,7 +24,7 @@
  *-->
 <template>
   <div class="panel">
-    <table 
+    <table
       class="table table-striped"
       v-for="(logs, requestIdentifier) in logsGroupedByRequest"
       :key="requestIdentifier"
@@ -40,7 +40,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr 
+        <tr
           v-for="log in logs"
           :key="log.id"
           :class="{ 'table-danger': (log.error === '1') }"

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -24,9 +24,11 @@
  *-->
 <template>
   <div class="panel">
-    <table class="table table-striped"
-    v-for="(logs, requestIdentifier) in logsGroupedByRequest"
-    :key="requestIdentifier">
+    <table 
+      class="table table-striped"
+      v-for="(logs, requestIdentifier) in logsGroupedByRequest"
+      :key="requestIdentifier"
+    >
       <thead>
         <tr>
           <th>#</th>
@@ -40,16 +42,14 @@
       <tbody>
         <tr v-for="log in logs"
         :key="log.id"
-        v-bind:class="{ 'table-danger': (log.error === '1') }">
+        :class="{ 'table-danger': (log.error === '1') }">
           <th scope="row">{{ log.id }}</th>
           <td>{{ log.hook_name }}</td>
           <td>{{ log.hook_parameters }}</td>
           <td>{{ log.output }}</td>
           <td>{{ log.called_at }}</td>
           <td>
-            <i
-              class="material-icons"
-            >
+            <i class="material-icons">
               <template v-if="log.error === '0'">
                 check
               </template>

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -24,19 +24,23 @@
  *-->
 <template>
   <div class="panel">
-    <table class="table table-striped" v-for="(logs, requestIdentifier) in logsGroupedByRequest" :key="requestIdentifier">
+    <table class="table table-striped"
+    v-for="(logs, requestIdentifier) in logsGroupedByRequest"
+    :key="requestIdentifier">
       <thead>
-      <tr>
-        <th>#</th>
-        <th>Hook</th>
-        <th>Parameters</th>
-        <th>Output</th>
-        <th>Time</th>
-        <th>Status</th>
-      </tr>
+        <tr>
+          <th>#</th>
+          <th>Hook</th>
+          <th>Parameters</th>
+          <th>Output</th>
+          <th>Time</th>
+          <th>Status</th>
+        </tr>
       </thead>
       <tbody>
-        <tr v-for="log in logs" :key="log.id" v-bind:class="{ 'table-danger': (log.error === '1') }">
+        <tr v-for="log in logs"
+        :key="log.id"
+        v-bind:class="{ 'table-danger': (log.error === '1') }">
           <th scope="row">{{ log.id }}</th>
           <td>{{ log.hook_name }}</td>
           <td>{{ log.hook_parameters }}</td>

--- a/_dev/back/router.js
+++ b/_dev/back/router.js
@@ -22,6 +22,7 @@ import Router from 'vue-router';
 import Index from '@/pages/Index';
 import Register from '@/pages/Register';
 import View from '@/pages/View';
+import Logs from '@/pages/Logs';
 
 Vue.use(Router);
 
@@ -38,6 +39,10 @@ const router = new Router({
     {
       path: '/view',
       component: View,
+    },
+    {
+      path: '/logs',
+      component: Logs,
     },
   ],
 });

--- a/controllers/admin/AdminQualityAssuranceController.php
+++ b/controllers/admin/AdminQualityAssuranceController.php
@@ -182,6 +182,7 @@ class AdminQualityAssuranceController extends ModuleAdminController
         $query->orderBy('id DESC');
         $query->limit(200);
 
+        /** @var array $logs */
         $logs = Db::getInstance()->executeS($query);
 
         $grouped = [];

--- a/controllers/admin/AdminQualityAssuranceController.php
+++ b/controllers/admin/AdminQualityAssuranceController.php
@@ -49,6 +49,7 @@ class AdminQualityAssuranceController extends ModuleAdminController
                     'registeredHooks' => $this->generateAjaxUrl('GetRegisteredHooks'),
                     'update' => $this->generateAjaxUrl('UpdateHook'),
                     'toggleHookStatus' => $this->generateAjaxUrl('ToggleHookStatus'),
+                    'logs' => $this->generateAjaxUrl('GetHookCallLogs'),
                 ],
             ],
         ]);
@@ -171,6 +172,28 @@ class AdminQualityAssuranceController extends ModuleAdminController
             'id = ' . $hookId
         );
         $this->renderJson([]);
+    }
+
+    public function ajaxProcessGetHookCallLogs()
+    {
+        $query = new DbQuery();
+        $query->select('*');
+        $query->from('quality_assurance_hook_logs');
+        $query->orderBy('id DESC');
+        $query->limit(200);
+
+        $logs = Db::getInstance()->executeS($query);
+
+        $grouped = [];
+        foreach ($logs as $log) {
+            $requestIdentifier = $log['request_identifier'];
+            if (!isset($grouped[$requestIdentifier])) {
+                $grouped[$requestIdentifier] = [];
+            }
+            $grouped[$requestIdentifier][] = $log;
+        }
+
+        $this->renderJson($grouped);
     }
 
     private function generateAjaxUrl($action)

--- a/ps_qualityassurance.php
+++ b/ps_qualityassurance.php
@@ -106,6 +106,7 @@ class Ps_Qualityassurance extends Module
 
         if (empty($payload['enabled'])) {
             $this->recordHookCall($hookName, $arguments);
+
             return;
         }
 
@@ -133,6 +134,7 @@ class Ps_Qualityassurance extends Module
      * Look whether there is a payload registered for this hook
      *
      * @param string $hookName
+     *
      * @return array|null
      */
     protected function getRegisteredHookPayload($hookName)
@@ -191,7 +193,7 @@ class Ps_Qualityassurance extends Module
             } elseif (is_object($value)) {
                 $result[$key] = sprintf('Object %s', get_class($value));
             } else {
-                $result[$key] = (string)$value;
+                $result[$key] = (string) $value;
             }
         }
 

--- a/ps_qualityassurance.php
+++ b/ps_qualityassurance.php
@@ -67,7 +67,7 @@ class Ps_Qualityassurance extends Module
 
     public function install()
     {
-        $query = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'quality_assurance_hooks` (' .
+        $createHookTableQuery = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'quality_assurance_hooks` (' .
             '`id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,' .
             '`name` varchar(255) NOT NULL,' .
             '`content` text NOT NULL,' .
@@ -76,7 +76,7 @@ class Ps_Qualityassurance extends Module
             'UNIQUE KEY `name` (`name`)' .
             ') ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
-        $query2 = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'quality_assurance_hook_logs` (' .
+        $createHookLogsQuery = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'quality_assurance_hook_logs` (' .
             '`id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,' .
             '`request_identifier` varchar(255) NOT NULL,' .
             '`hook_name` varchar(255) NOT NULL,' .
@@ -87,8 +87,8 @@ class Ps_Qualityassurance extends Module
             'PRIMARY KEY (`id`)' .
             ') ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
-        return Db::getInstance()->execute($query1)
-            && Db::getInstance()->execute($query2)
+        return Db::getInstance()->execute($createHookTableQuery)
+            && Db::getInstance()->execute($createHookLogsQuery)
             && parent::install();
     }
 
@@ -101,8 +101,6 @@ class Ps_Qualityassurance extends Module
     public function __call($methodName, array $arguments)
     {
         $hookName = preg_replace('~^hook~', '', $methodName);
-
-        $arguments[4] = ['4' => ['5' => []]];
 
         $payload = $this->getRegisteredHookPayload($hookName);
 
@@ -158,7 +156,7 @@ class Ps_Qualityassurance extends Module
      *
      * @return bool
      */
-    protected function recordHookCall(string $hookName, array $arguments, ?string $output = null, ?bool $error = false)
+    protected function recordHookCall($hookName, array $arguments, $output = null, $error = false)
     {
         $requestIdentifier = $this->getRequestIdentifier();
 
@@ -206,7 +204,7 @@ class Ps_Qualityassurance extends Module
     protected function getRequestIdentifier()
     {
         if ($this->requestIdentifier === null) {
-            $this->requestIdentifier = random_bytes(20);
+            $this->requestIdentifier = uniqid();
         }
 
         return $this->requestIdentifier;

--- a/ps_qualityassurance.php
+++ b/ps_qualityassurance.php
@@ -39,6 +39,14 @@ class Ps_Qualityassurance extends Module
         ],
     ];
 
+    /**
+     * A HTTP request identifier to be able to
+     * gather hook call logs that have been triggered by the same request
+     *
+     * @var string
+     */
+    protected $requestIdentifier;
+
     public function __construct()
     {
         $this->name = 'ps_qualityassurance';
@@ -68,7 +76,20 @@ class Ps_Qualityassurance extends Module
             'UNIQUE KEY `name` (`name`)' .
             ') ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
 
-        return Db::getInstance()->execute($query) && parent::install();
+        $query2 = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'quality_assurance_hook_logs` (' .
+            '`id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,' .
+            '`request_identifier` varchar(255) NOT NULL,' .
+            '`hook_name` varchar(255) NOT NULL,' .
+            '`hook_parameters` text NOT NULL,' .
+            '`output` text NOT NULL,' .
+            '`called_at` datetime NOT NULL,' .
+            '`error` TINYINT(1) NOT NULL,' .
+            'PRIMARY KEY (`id`)' .
+            ') ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=UTF8;';
+
+        return Db::getInstance()->execute($query1)
+            && Db::getInstance()->execute($query2)
+            && parent::install();
     }
 
     /**
@@ -81,20 +102,26 @@ class Ps_Qualityassurance extends Module
     {
         $hookName = preg_replace('~^hook~', '', $methodName);
 
-        $query = new DbQuery();
-        $query->select('content')
-              ->select('enabled');
-        $query->from('quality_assurance_hooks');
-        $query->where('name = "' . pSQL($hookName) . '"');
+        $arguments[4] = ['4' => ['5' => []]];
 
-        $row = Db::getInstance()->getRow($query);
-        if (!empty($row['enabled'])) {
-            $params = !empty($arguments[0]) ? $arguments[0] : [];
-            try {
-                return eval($row['content']);
-            } catch (Throwable $e) {
-                echo $e->getMessage();
-            }
+        $payload = $this->getRegisteredHookPayload($hookName);
+
+        if (empty($payload['enabled'])) {
+            $this->recordHookCall($hookName, $arguments);
+            return;
+        }
+
+        $params = !empty($arguments[0]) ? $arguments[0] : [];
+        try {
+            $output = eval($payload['content']);
+            $this->recordHookCall($hookName, $params, $output);
+
+            return $output;
+        } catch (Throwable $e) {
+            $output = $e->getMessage();
+            $this->recordHookCall($hookName, $params, $output, true);
+
+            echo $output;
         }
     }
 
@@ -102,5 +129,86 @@ class Ps_Qualityassurance extends Module
     {
         $moduleAdminLink = Context::getContext()->link->getAdminLink('AdminQualityAssurance', true);
         Tools::redirectAdmin($moduleAdminLink);
+    }
+
+    /**
+     * Look whether there is a payload registered for this hook
+     *
+     * @param string $hookName
+     * @return array|null
+     */
+    protected function getRegisteredHookPayload($hookName)
+    {
+        $query = new DbQuery();
+        $query->select('content')
+            ->select('enabled');
+        $query->from('quality_assurance_hooks');
+        $query->where('name = "' . pSQL($hookName) . '"');
+
+        $row = Db::getInstance()->getRow($query);
+
+        return $row;
+    }
+
+    /**
+     * @param string $hookName
+     * @param array $arguments
+     * @param string|null $output
+     * @param bool|null $error
+     *
+     * @return bool
+     */
+    protected function recordHookCall(string $hookName, array $arguments, ?string $output = null, ?bool $error = false)
+    {
+        $requestIdentifier = $this->getRequestIdentifier();
+
+        $parameters = sprintf("('%s', '%s', '%s', '%s', now(), %d)",
+            pSQL($requestIdentifier),
+            pSQL($hookName),
+            $this->makeArgumentsReadable($arguments),
+            sprintf('%s: %s',
+                (!$error ? 'Output' : 'Error'),
+                pSQL($output)
+            ),
+            ($error ? 1 : 0)
+        );
+
+        $sql = 'INSERT INTO ' . _DB_PREFIX_ . 'quality_assurance_hook_logs (request_identifier, hook_name, hook_parameters, output, called_at, error) VALUES '
+            . $parameters;
+
+        return Db::getInstance()->execute($sql);
+    }
+
+    /**
+     * @param array $arguments
+     *
+     * @return string
+     */
+    protected function makeArgumentsReadable(array $arguments)
+    {
+        $result = [];
+        foreach ($arguments as $key => $value) {
+            if (is_array($value)) {
+                $result[$key] = 'Array';
+            } elseif (is_object($value)) {
+                $result[$key] = sprintf('Object %s', get_class($value));
+            } else {
+                $result[$key] = (string)$value;
+            }
+        }
+
+        return json_encode($result);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getRequestIdentifier()
+    {
+        if ($this->requestIdentifier === null) {
+            $this->requestIdentifier = random_bytes(20);
+        }
+
+        return $this->requestIdentifier;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Enable recording hook calls. In this PR I add a SQL table to store each call to a hook. These logs can be monitored inside the VueJS APP in BO.
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_qualityassurance/issues/6
| How to test?  | 

It looks like this:
![Capture d’écran 2020-12-03 à 11 28 55](https://user-images.githubusercontent.com/3830050/100998179-7b306f80-355b-11eb-8f69-e830858d4d87.png)
![Capture d’écran 2020-12-03 à 11 29 02](https://user-images.githubusercontent.com/3830050/100998189-7d92c980-355b-11eb-8d91-fe66880745e9.png)

So basically
- every time you use ps_qualityassurance connected to one hook
- this call is recorded in a logs table
- logs table can be viewed in the Module BO page

So you can see what hooks have been called, with date, parameters, output :)