### PR TITLE
Enable record js events

### DIFF
--- a/_dev/back/index.scss
+++ b/_dev/back/index.scss
@@ -30,3 +30,7 @@
 .modal-backdrop {
   opacity: 0.5;
 }
+
+.panel-buttons {
+  margin: 3px;
+}

--- a/_dev/back/lib/api.js
+++ b/_dev/back/lib/api.js
@@ -75,6 +75,12 @@ const api = {
   getHookCallLogs() {
     return makeGetRequest(urls.logs);
   },
+  refreshJSEventListenerStatus() {
+    return makeGetRequest(urls.jsEventListenerStatus);
+  },
+  toggleJSEventListener() {
+    return makePostRequest(urls.toggleJSEventListener, {});
+  },
 };
 
 export default api;

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -36,10 +36,10 @@
 
       <button
         class="btn"
-        :class="{'btn-success': !isJSEventListenerIsEnabled(), 'btn-warning': isJSEventListenerIsEnabled()}"
+        :class="{'btn-success': !jsEventListenerIsEnabled, 'btn-warning': jsEventListenerIsEnabled}"
         @click.prevent="toggleJSEventListener()"
       >
-        <template v-if="isJSEventListenerIsEnabled()">
+        <template v-if="jsEventListenerIsEnabled">
           Disable JS Events Listener
         </template>
         <template v-else>
@@ -125,9 +125,6 @@
         api.toggleJSEventListener().then(() => {
           this.refreshJSEventListenerStatus();
         });
-      },
-      isJSEventListenerIsEnabled() {
-        return this.jsEventListenerIsEnabled;
       },
     },
   };

--- a/_dev/back/pages/Logs.vue
+++ b/_dev/back/pages/Logs.vue
@@ -24,6 +24,35 @@
  *-->
 <template>
   <div class="panel">
+    <div class="panel-buttons">
+      <button
+        type="button"
+        class="btn btn-primary"
+        @click.prevent="refreshLogs()"
+      >
+        REFRESH LOGS
+        <i class="material-icons">refresh</i>
+      </button>
+
+      <button
+        class="btn"
+        :class="{'btn-success': !isJSEventListenerIsEnabled(), 'btn-warning': isJSEventListenerIsEnabled()}"
+        @click.prevent="toggleJSEventListener()"
+      >
+        <template v-if="isJSEventListenerIsEnabled()">
+          Disable JS Events Listener
+        </template>
+        <template v-else>
+          Enable JS Events Listener
+        </template>
+      </button>
+    </div>
+
+    <div class="alert alert-warning" role="alert">
+      Module PS Quality Assurance is hooked on hook 'displayTop' (alias 'header')
+      so the logs related to this hook are not displayed here.
+    </div>
+
     <table
       class="table table-striped"
       v-for="(logs, requestIdentifier) in logsGroupedByRequest"
@@ -73,17 +102,32 @@
     name: 'Logs',
     data() {
       return {
+        jsEventListenerIsEnabled: false,
         logsGroupedByRequest: [],
       };
     },
     mounted() {
       this.refreshLogs();
+      this.refreshJSEventListenerStatus();
     },
     methods: {
       refreshLogs() {
         api.getHookCallLogs().then((res) => {
           this.logsGroupedByRequest = res.data;
         });
+      },
+      refreshJSEventListenerStatus() {
+        api.refreshJSEventListenerStatus().then((res) => {
+          this.jsEventListenerIsEnabled = res.data;
+        });
+      },
+      toggleJSEventListener() {
+        api.toggleJSEventListener().then(() => {
+          this.refreshJSEventListenerStatus();
+        });
+      },
+      isJSEventListenerIsEnabled() {
+        return this.jsEventListenerIsEnabled;
       },
     },
   };

--- a/controllers/admin/AdminQualityAssuranceController.php
+++ b/controllers/admin/AdminQualityAssuranceController.php
@@ -50,6 +50,8 @@ class AdminQualityAssuranceController extends ModuleAdminController
                     'update' => $this->generateAjaxUrl('UpdateHook'),
                     'toggleHookStatus' => $this->generateAjaxUrl('ToggleHookStatus'),
                     'logs' => $this->generateAjaxUrl('GetHookCallLogs'),
+                    'jsEventListenerStatus' => $this->generateAjaxUrl('GetJSEventListenerStatus'),
+                    'toggleJSEventListener' => $this->generateAjaxUrl('ToggleJSEventListener'),
                 ],
             ],
         ]);
@@ -101,6 +103,11 @@ class AdminQualityAssuranceController extends ModuleAdminController
     public function ajaxProcessGetHooks()
     {
         $this->renderJson(Hook::getHooks());
+    }
+
+    public function ajaxProcessGetJSEventListenerStatus()
+    {
+        $this->renderJson((bool) Configuration::get('PS_QA_MODULE_LISTEN_JS'));
     }
 
     public function ajaxProcessGetRegisteredHooks()
@@ -195,6 +202,14 @@ class AdminQualityAssuranceController extends ModuleAdminController
         }
 
         $this->renderJson($grouped);
+    }
+
+    public function ajaxProcessToggleJSEventListener()
+    {
+        $oldStatus = Configuration::get('PS_QA_MODULE_LISTEN_JS');
+        $result = Configuration::updateValue('PS_QA_MODULE_LISTEN_JS', ($oldStatus ? 0 : 1));
+        
+        $this->renderJson($result);
     }
 
     private function generateAjaxUrl($action)

--- a/controllers/admin/AdminQualityAssuranceController.php
+++ b/controllers/admin/AdminQualityAssuranceController.php
@@ -207,8 +207,8 @@ class AdminQualityAssuranceController extends ModuleAdminController
     public function ajaxProcessToggleJSEventListener()
     {
         $oldStatus = Configuration::get('PS_QA_MODULE_LISTEN_JS');
-        $result = Configuration::updateValue('PS_QA_MODULE_LISTEN_JS', ($oldStatus ? 0 : 1));
-        
+        $result = Configuration::updateValue('PS_QA_MODULE_LISTEN_JS', (bool) $oldStatus);
+
         $this->renderJson($result);
     }
 

--- a/controllers/front/listener.php
+++ b/controllers/front/listener.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+class ps_qualityassurancelistenerModuleFrontController extends ModuleFrontController
+{
+    public function display()
+    {
+        if (!$this->jsEventListenerIsEnabled()) {
+            return;
+        }
+
+        if (Tools::getValue('action') !== 'RecordJSHookExecution') {
+            $this->ajaxDie('Unknown action');
+        }
+
+        $this->processRecordJSHookExecution();
+    }
+
+    public function processRecordJSHookExecution()
+    {
+        $hookName = (string) Tools::getValue('name');
+
+        if (!$hookName) {
+            $this->ajaxRender(
+                'Missing hook name',
+                get_class($this),
+                'ajaxProcessRecordJSHookExecution'
+            );
+            die();
+        }
+
+        Db::getInstance()->insert(
+            'quality_assurance_hook_logs',
+            [
+                'request_identifier' => uniqid(),
+                'hook_name' => 'JS Event - ' . pSQL($hookName),
+                'hook_parameters' => pSQL(Tools::getValue('parameters'), true),
+                'output' => '',
+                'called_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+                'error' => 0,
+            ]
+        );
+        $this->ajaxDie('Execution registered');
+    }
+
+    /**
+     * @return bool
+     */
+    protected function jsEventListenerIsEnabled()
+    {
+        return (bool) Configuration::get('PS_QA_MODULE_LISTEN_JS');
+    }
+}

--- a/views/js/ps_event_listener.js
+++ b/views/js/ps_event_listener.js
@@ -42,14 +42,17 @@ const allPrestaShopJSEvents = [
 ];
 
 $(document).ready(function () {
+
   allPrestaShopJSEvents.forEach(function(eventName) {
-    const listenerParameters = '&fc=module&module=ps_qualityassurance&controller=listener&action=RecordJSHookExecution';
+    const listenerParameters = '&fc=module&module=ps_qualityassurance&controller=listener&action=RecordJSHookExecution&ajax=true';
 
     prestashop.on(eventName, function(event) {
-      let xhr = new XMLHttpRequest();
-      xhr.open('POST', '/');
-      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-      xhr.send(encodeURI('name='+eventName+listenerParameters));
+      $.post({
+        url: '/?name='+eventName+listenerParameters,
+        data: '',
+        dataType: 'json',
+        cache: false,
+      });
     });
-  })
+  });
 });

--- a/views/js/ps_event_listener.js
+++ b/views/js/ps_event_listener.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+const allPrestaShopJSEvents = [
+  'handleError',
+  'showErrorNextToAddtoCartButton',
+  'updateProductList',
+  'updateProduct',
+  'responsive',
+  'updateProductQuantityInCart',
+  'updateFacets',
+  'updateCart',
+  'updatedCart',
+  'clickQuickView',
+  'changedCheckoutStep',
+  'editAddress',
+  'updatedAddressForm',
+  'updatedDeliveryForm',
+  'editDelivery',
+];
+
+$(document).ready(function () {
+  allPrestaShopJSEvents.forEach(function(eventName) {
+    const listenerParameters = '&fc=module&module=ps_qualityassurance&controller=listener&action=RecordJSHookExecution';
+
+    prestashop.on(eventName, function(event) {
+      let xhr = new XMLHttpRequest();
+      xhr.open('POST', '/');
+      xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+      xhr.send(encodeURI('name='+eventName+listenerParameters));
+    });
+  })
+});


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Enable record PrestaShop JS object events emitted. QA analyst can monitor them. PR done on a branch that is based on branch https://github.com/PrestaShop/ps_qualityassurance/pull/8
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/ps_qualityassurance/issues/4
| How to test?  | 

## Details

In this PR, I enable the module to hook on `header` hook. With this header, I can inject a JavaScript script that listen to `prestashop` object and for every known emitted event, calls a Front Controller to record the call.

The calls are rendered as logs. I added a "Toggle JS events" button and a "Refresh logs" button in the "Hook Call Logs" view introduced by https://github.com/PrestaShop/ps_qualityassurance/pulls.

There is 2 limitations for this PR
- I only listen to the events I know, I did not find a way to "listen to any event emitted" (help @NeOMakinG)
- Because the module hooks on `header`, the hook `header` spams the logs page so I excluded it from the list. QA analysts cannot see it in the logs.
