### PR TITLE
Improve default payload to use var_export

### DIFF
--- a/_dev/back/components/hook/Register.vue
+++ b/_dev/back/components/hook/Register.vue
@@ -99,7 +99,7 @@
         if (item.name.startsWith('display')) {
           this.form.content = 'return \'<img src="\' . Tools::getAdminImageUrl(\'prestashop-avatar.png\') . \'" />\';';
         } else if (item.name.startsWith('action')) {
-          this.form.content = 'dump($params);';
+          this.form.content = 'return var_export($params, true);';
         }
       },
       getLabel(item) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The default payload is `dump($params);` . This is not very helpful as it will sent to browser the dumped object, unless you also use a `die();` .<br/><br/>I suggest to rather use var_export to return the state of the parameters, and they can be seen inside the hook logs. See screenshot below
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | See below

### How to test

1. Install ps_qualityassurance
2. Register 2 hooks: actionObjectCustomerUpdateBefore and actionObjectCustomerUpdateAfter.
3. Edit a customer from back office
4. Inside "hook call logs" in ps_qualityassurance configuration page you can see the logs contain the state of the customer object.

### Screenshot

![Capture d’écran 2021-08-05 à 17 34 10](https://user-images.githubusercontent.com/3830050/128378641-9564fff0-27cc-45a6-824d-99bf4527984d.png)
