### PR TITLE
Remove Node 9, add Node 14, bump webpack and sass version

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-versions: ['9', '10', '12']
+        node-versions: ['10', '12', '14']
     runs-on: ubuntu-latest
     name: JS Lint
     steps:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-versions: ['10', '12', '14']
+        node-versions: ['14', '16']
     runs-on: ubuntu-latest
     name: JS Lint
     steps:

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
     "eslint-plugin-vue": "^5.2.2",
     "mini-css-extract-plugin": "^0.5.0",
     "mocha": "^7.1.1",
-    "node-sass": "^4.11.0",
-    "sass-loader": "^7.1.0",
+    "node-sass": "^6.0.1",
+    "sass-loader": "^10.4.1",
     "style-loader": "^0.23.1",
     "vue-template-compiler": "^2.6.10",
-    "webpack": "^4.29.6",
-    "webpack-cli": "^3.2.3"
+    "webpack": "^4.46.0",
+    "webpack-cli": "^4.10.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Node 9 was EOL 5 years ago. devDependencies are in need of bumping.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | Run `npm install` and `npm run build` with Node 14
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
