### PR TITLE
Upgrade github actions from v1/v2 to v3

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     name: JS Lint
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-versions }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v2.0.0
+              uses: actions/checkout@v3.1.0
 
             - name: PHP syntax checker 5.6
               uses: prestashop/github-action-php-lint/5.6@master
@@ -32,10 +32,10 @@ jobs:
                 php-version: '7.4'
 
             - name: Checkout
-              uses: actions/checkout@v2.0.0
+              uses: actions/checkout@v3.1.0
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: vendor
                 key: php-${{ hashFiles('composer.lock') }}
@@ -60,18 +60,18 @@ jobs:
                 php-version: '7.4'
 
             - name: Checkout
-              uses: actions/checkout@v2.0.0
+              uses: actions/checkout@v3.1.0
 
             # Add vendor folder in cache to make next builds faster
             - name: Cache vendor folder
-              uses: actions/cache@v1
+              uses: actions/cache@v3
               with:
                 path: vendor
                 key: php-${{ hashFiles('composer.lock') }}
 
             # Add composer local folder in cache to make next builds faster
             - name: Cache composer folder
-              uses: actions/cache@v1
+              uses: actions/cache@v3
               with:
                 path: ~/.composer/cache
                 key: php-composer-cache


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | github actions (cache, setup-node, checkout) need to be updated from v1/v2 to v3 to match with Node14/16 env.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue URL here}, Fixes #{another issue URL here}
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | Automatic JS tests, PHP tests complete without warnings of github actions' deprecated v1/v2
